### PR TITLE
Fixing flags overlap

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -9,4 +9,5 @@
 }
 .translations img {
 	height: 2em;
+        display: block;
 }


### PR DESCRIPTION
Current CSS puts flags overlapping first menu item. Fixed with inline: block. Now flags are displayed at far left in menu column.
