### PR TITLE
Update index.md with correct Juniper SRX information

### DIFF
--- a/index.md
+++ b/index.md
@@ -47,7 +47,7 @@ To remediate problems please upgrade your DNS software to the latest stable vers
 
 Vendor hints:
 
-* Older versions of Juniper SRX will drop EDNS packets by default - Workaround is to disable DNS doctoring via `# set security alg dns doctoring none` ([docs](https://www.juniper.net/documentation/en_US/junos/topics/topic-map/security-dns-algs.html)) Newer versions of Juniper SRX support EDNS by default (12.3X48-D80, 15.1X49-D160, 17.4R3, 18.1R3, 18.2R2, and 18.3R1+).
+* Older versions of Juniper SRX will drop EDNS packets by default - Workaround is to disable DNS doctoring via `# set security alg dns doctoring none`. Upgrade to latest versions for EDNS support. 
 * [F5 BIG-IP DNS processing and DNS Flag Day](https://support.f5.com/csp/article/K07808381?sf206085287=1)
 * [BlueCat is ready](https://www.bluecatnetworks.com/blog/dns-flag-day-is-coming-and-bluecat-is-ready/)
 * [DNS Flag Day and Akamai](https://community.akamai.com/customers/s/article/CloudSecurityDNSFlagDayandAkamai20190115151216?language=en_US)

--- a/index.md
+++ b/index.md
@@ -47,7 +47,7 @@ To remediate problems please upgrade your DNS software to the latest stable vers
 
 Vendor hints:
 
-* Juniper SRX may drop EDNS packets - to disable use: `# set security alg dns disable` ([docs](https://www.juniper.net/documentation/en_US/junos/topics/topic-map/security-dns-algs.html))
+* Older versions of Juniper SRX will drop EDNS packets by default - Workaround is to disable DNS doctoring via `# set security alg dns doctoring none` ([docs](https://www.juniper.net/documentation/en_US/junos/topics/topic-map/security-dns-algs.html)) Newer versions of Juniper SRX support EDNS by default (12.3X48-D80, 15.1X49-D160, 17.4R3, 18.1R3, 18.2R2, and 18.3R1+).
 * [F5 BIG-IP DNS processing and DNS Flag Day](https://support.f5.com/csp/article/K07808381?sf206085287=1)
 * [BlueCat is ready](https://www.bluecatnetworks.com/blog/dns-flag-day-is-coming-and-bluecat-is-ready/)
 * [DNS Flag Day and Akamai](https://community.akamai.com/customers/s/article/CloudSecurityDNSFlagDayandAkamai20190115151216?language=en_US)


### PR DESCRIPTION
Updated Juniper SRX information. You don't have to disable the ALG, you can just set doctoring to none
Also, newer versions support EDNS without modifying the ALG. Those versions are:
12.3X48-D80
15.1X49-D160
17.4R3
18.1R3
18.2R2
18.3R1 and newer

Will update text with a link instead when a public KB has been published.

Thanks!