### PR TITLE
2020 index nitpicks: make links clickable

### DIFF
--- a/index.md
+++ b/index.md
@@ -218,10 +218,10 @@ Get in touch
 For press & media inquiries please use media (at) dns-oarc.net and please put
 “DNS Flag Day" in the email subject line.
 
-- Web https://dnsflagday.net/
-- Twitter https://twitter.com/dnsflagday
-- Announcements: https://lists.dns-oarc.net/mailman/listinfo/dns-announce
-- Discussion: https://lists.dns-oarc.net/mailman/listinfo/dns-operations
+- Web: <https://dnsflagday.net/>
+- Twitter: <https://twitter.com/dnsflagday>
+- Announcements: <https://lists.dns-oarc.net/mailman/listinfo/dns-announce>
+- Discussion: <https://lists.dns-oarc.net/mailman/listinfo/dns-operations>
 
 FAQ
 ===


### PR DESCRIPTION
but keep them visible, and use semicolons consistently in the section.

GitHub did show these as clickable, but for the web I suspect we need to make that explicit.