### PR TITLE
Revert "client-tcp-checker: use HTTPS for cmdns.dev.dns-oarc.net requests

### DIFF
--- a/js/client-tcp-checker.js
+++ b/js/client-tcp-checker.js
@@ -21,7 +21,7 @@ var clientTcpChecker = function(init) {
                 $('#client-tcp-checker-result').html(init.texts.reportFailHtml);
             });
 
-            img.attr('src', 'https://dnsflagdaytcp.cmdns.dev.dns-oarc.net/dot.png');
+            img.attr('src', 'http://dnsflagdaytcp.cmdns.dev.dns-oarc.net/dot.png');
             console.log('loading');
             $('#client-tcp-checker-status').text(init.status.loading);
         });
@@ -33,7 +33,7 @@ var clientTcpChecker = function(init) {
         });
 
         $('#client-tcp input[type="submit"]').attr('disabled', true);
-        img.attr('src', 'https://cmdns.dev.dns-oarc.net/dot.png');
+        img.attr('src', 'http://cmdns.dev.dns-oarc.net/dot.png');
         console.log('checking network');
         $('#client-tcp-checker-status').text(init.status.checkNetwork);
 


### PR DESCRIPTION
This reverts commit cc9ff6cdc6299d82a2282d9e2199659d2ceda578.

It in fact broken the test. We need to look into HTTPS support eventually because some browser configurations do not allow to load mixed content from third-party web sites at all.