### PR TITLE
[flagday2020] Add instructions for CoreDNS

### DIFF
--- a/2020/index-es.md
+++ b/2020/index-es.md
@@ -204,48 +204,7 @@ de servicio puede probar sus servicios autoritativos y
 resolutores configurando los siguientes
 tamaños por defecto de buffer EDNS:
 
-- BIND
-```
-options {
-    edns-udp-size 1232;
-    max-udp-size 1232;
-};
-```
-
-- Knot DNS
-```
-server:
-    max-udp-payload: 1232
-```
-
-- Knot Resolver
-```
-net.bufsize(1232)
-```
-
-- PowerDNS Authoritative
-```
-udp-truncation-threshold=1232
-```
-
-- PowerDNS Recursor
-```
-edns-outgoing-bufsize=1232
-udp-truncation-threshold=1232
-```
-
-- Unbound
-```
-server:
-    edns-buffer-size: 1232
-```
-
-- NSD
-```
-server:
-    ipv4-edns-size: 1232
-    ipv6-edns-size: 1232
-```
+{% include 2020_server_configs.md %}
 
 La configuración indicada no ocasionará cambios visibles en caso que
 todo funcione correctamente, pero algunas consultas fallarán en su

--- a/2020/index-fr.md
+++ b/2020/index-fr.md
@@ -130,48 +130,7 @@ Toutes les requêtes DNS doivent aboutir et les commandes avec ou sans l'option 
 
 Si vous êtes un FAI, vous pouvez tester vos serveurs faisant autorité et récursifs en changeant la configuration pour la taille par défaut du tampon EDNS:
 
-- BIND
-```
-options {
-    edns-udp-size 1232;
-    max-udp-size 1232;
-};
-```
-
-- Knot DNS
-```
-server:
-    max-udp-payload: 1232
-```
-
-- Knot Resolver
-```
-net.bufsize(1232)
-```
-
-- PowerDNS Authoritative
-```
-udp-truncation-threshold=1232
-```
-
-- PowerDNS Recursor
-```
-edns-outgoing-bufsize=1232
-udp-truncation-threshold=1232
-```
-
-- Unbound
-```
-server:
-    edns-buffer-size: 1232
-```
-
-- NSD
-```
-server:
-    ipv4-edns-size: 1232
-    ipv6-edns-size: 1232
-```
+{% include 2020_server_configs.md %}
 
 La configuration ci-dessus n'aura aucun impact si tout fonctionne correctement, mais certaines requêtes échoueront si TCP n'est pas disponible.
 

--- a/2020/index-ja.md
+++ b/2020/index-ja.md
@@ -180,48 +180,7 @@ $ dig @resolver_IP test.knot-resolver.cz. TXT
 DNS サービスの提供者の方は、権威 DNS サーバーやフルサービスリゾルバーを下記のように
 EDNS バッファーサイズのデフォルト値を変更してテストすることができます:
 
-- BIND
-```
-options {
-    edns-udp-size 1232;
-    max-udp-size 1232;
-};
-```
-
-- Knot DNS
-```
-server:
-    max-udp-payload: 1232
-```
-
-- Knot Resolver
-```
-net.bufsize(1232)
-```
-
-- PowerDNS Authoritative
-```
-udp-truncation-threshold=1232
-```
-
-- PowerDNS Recursor
-```
-edns-outgoing-bufsize=1232
-udp-truncation-threshold=1232
-```
-
-- Unbound
-```
-server:
-    edns-buffer-size: 1232
-```
-
-- NSD
-```
-server:
-    ipv4-edns-size: 1232
-    ipv6-edns-size: 1232
-```
+{% include 2020_server_configs.md %}
 
 変更前に何の問題もなくサービスできていれば、上記の設定変更を適用しても影響はありません。
 TCP で応答していない場合には、一部の問い合わせが失敗するようになるでしょう。

--- a/2020/index-zh-CN.md
+++ b/2020/index-zh-CN.md
@@ -130,48 +130,7 @@ $ dig @resolver_IP test.knot-resolver.cz. TXT
 ```
 无论是否使用‘+tcp’选项,所有的DNS查询必须是成功的。如果你是一项业务的提供商，你也可以通过允许DNS支持TCP，以及改变下面默认的EDNS 缓冲区大小的配置来测试你的权威和递归服务。
 
-- BIND
-```
-options {
-    edns-udp-size 1232;
-    max-udp-size 1232;
-};
-```
-
-- Knot DNS
-```
-server:
-    max-udp-payload: 1232
-```
-
-- Knot Resolver
-```
-net.bufsize(1232)
-```
-
-- PowerDNS Authoritative
-```
-udp-truncation-threshold=1232
-```
-
-- PowerDNS Recursor
-```
-edns-outgoing-bufsize=1232
-udp-truncation-threshold=1232
-```
-
-- Unbound
-```
-server:
-    edns-buffer-size: 1232
-```
-
-- NSD
-```
-server:
-    ipv4-edns-size: 1232
-    ipv6-edns-size: 1232
-```
+{% include 2020_server_configs.md %}
 
 如果一切工作正常（支持TCP），以上的配置不会有明显的影响。如果递归或者权威不支持TCP，一些查询就会失败。
 

--- a/2020/index.md
+++ b/2020/index.md
@@ -203,57 +203,7 @@ results both with and without the `+tcp` option.
 If you are a service provider, you can test your authoritative and
 recursive DNS services by configuring the default EDNS buffer size:
 
-- BIND
-```
-options {
-    edns-udp-size 1232;
-    max-udp-size 1232;
-};
-```
-
-- CoreDNS
-```
-. {
-    bufsize 1232
-    file db.example.org
-    log
-}
-```
-
-- Knot DNS
-```
-server:
-    max-udp-payload: 1232
-```
-
-- Knot Resolver
-```
-net.bufsize(1232)
-```
-
-- PowerDNS Authoritative
-```
-udp-truncation-threshold=1232
-```
-
-- PowerDNS Recursor
-```
-edns-outgoing-bufsize=1232
-udp-truncation-threshold=1232
-```
-
-- Unbound
-```
-server:
-    edns-buffer-size: 1232
-```
-
-- NSD
-```
-server:
-    ipv4-edns-size: 1232
-    ipv6-edns-size: 1232
-```
+{% include 2020_server_configs.md %}
 
 The configuration above will have no visible effect if everything works
 correctly. Some queries will fail to resolve if the TCP transport is not

--- a/2020/index.md
+++ b/2020/index.md
@@ -211,6 +211,15 @@ options {
 };
 ```
 
+- CoreDNS
+```
+. {
+    bufsize 1232
+    file db.example.org
+    log
+}
+```
+
 - Knot DNS
 ```
 server:

--- a/_includes/2020_server_configs.md
+++ b/_includes/2020_server_configs.md
@@ -1,0 +1,53 @@
+- BIND
+```
+options {
+    edns-udp-size 1232;
+    max-udp-size 1232;
+};
+```
+
+- CoreDNS
+```
+. {
+    bufsize 1232
+    file db.example.or
+    log
+}
+```
+
+- Knot DNS
+```
+server:
+    max-udp-payload: 1232
+```
+
+- Knot Resolver
+```
+net.bufsize(1232)
+```
+
+- PowerDNS Authoritative
+```
+udp-truncation-threshold=1232
+```
+
+- PowerDNS Recursor
+```
+edns-outgoing-bufsize=1232
+udp-truncation-threshold=1232
+```
+
+- Unbound
+```
+server:
+    edns-buffer-size: 1232
+```
+
+- NSD
+```
+server:
+    ipv4-edns-size: 1232
+    ipv6-edns-size: 1232
+```
+
+


### PR DESCRIPTION
CoreDNS has a [bufsize plugin](https://coredns.io/plugins/bufsize/) that can be used to force the bufsize used. This PR adds instruction to set it to 1232 in CoreDNS config.